### PR TITLE
allow sending custom data with the requesttelemetry

### DIFF
--- a/src/ApplicationInsights.OwinExtensions/AppBuilderExtension.cs
+++ b/src/ApplicationInsights.OwinExtensions/AppBuilderExtension.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using Microsoft.ApplicationInsights.Extensibility;
 using Microsoft.Owin;
 using Owin;
@@ -10,10 +11,11 @@ namespace ApplicationInsights.OwinExtensions
         public static IAppBuilder UseApplicationInsights(this IAppBuilder builder,
             OperationIdContextMiddlewareConfiguration middlewareConfiguration = null,
             TelemetryConfiguration telemetryConfiguration = null,
-            Func<IOwinRequest, IOwinResponse, bool> shouldTraceRequest = null)
+            Func<IOwinRequest, IOwinResponse, bool> shouldTraceRequest = null,
+            Func<IOwinRequest, IOwinResponse, KeyValuePair<string,string>[]> getContextProperties = null)
         {
             builder.Use<OperationIdContextMiddleware>(middlewareConfiguration);
-            builder.Use<HttpRequestTrackingMiddleware>(telemetryConfiguration, shouldTraceRequest);
+            builder.Use<HttpRequestTrackingMiddleware>(telemetryConfiguration, shouldTraceRequest, getContextProperties);
 
             return builder;
         }


### PR DESCRIPTION
This pull request adds the ability to send data that will appear under the Custom Data section for the Request Telemetry item.  This is useful for sending custom headers or any other request specific data.
 
![image](https://cloud.githubusercontent.com/assets/2425469/22296535/11674d7a-e2e0-11e6-8f66-b583cb4fb64f.png)
